### PR TITLE
Disabled BT MAP causing cyclic BT reconnect

### DIFF
--- a/aosp_rpi4_car.mk
+++ b/aosp_rpi4_car.mk
@@ -28,6 +28,7 @@ PRODUCT_VENDOR_PROPERTIES += \
     bluetooth.profile.hfp.ag.enabled=false \
     bluetooth.profile.hid.device.enabled=false \
     bluetooth.profile.hid.host.enabled=false \
+    bluetooth.profile.map.client.enabled=false \
     bluetooth.profile.map.server.enabled=false \
     bluetooth.profile.mcp.server.enabled=false \
     bluetooth.profile.opp.enabled=false \


### PR DESCRIPTION
Disabled BT Message Access Profile. Workaround to keep connection to the paired device. 
